### PR TITLE
Updating to a new version of guzzle to support PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "6.*"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "5.3.*",
-        "php-vcr/php-vcr": "dev-master"
+        "guzzlehttp/guzzle": "7.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Unfortunately in order to make this work we had to remove PHPUnit, this will be added down the line as I am mid migration of another larger project